### PR TITLE
Fix tee to append

### DIFF
--- a/.github/workflows/update-bot.yaml
+++ b/.github/workflows/update-bot.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - run: |
           echo "\`\`\`" > uv_output.md
-          uv lock --upgrade 2>&1 | tee uv_output.md
+          uv lock --upgrade 2>&1 | tee -a uv_output.md
           echo "\`\`\`" >> uv_output.md
 
       - name: Create pull request

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ jobs:
 
       - run: |
           echo "\`\`\`" > uv_output.md
-          uv lock --upgrade 2>&1 | tee uv_output.md
+          uv lock --upgrade 2>&1 | tee -a uv_output.md
           echo "\`\`\`" >> uv_output.md
 
       - name: Create pull request


### PR DESCRIPTION
The PR body wasn't in the code fence since `tee` wasn't called with `-a` to append, so the first code fence start wasn't in the file anymore.